### PR TITLE
Fixed cannot set headers bug

### DIFF
--- a/routes/reviews.js
+++ b/routes/reviews.js
@@ -74,8 +74,8 @@ const reviewValidators = [
     .withMessage('Please write a review before submitting!')
 ]
 
-// POST /games/:id/reviews/add
-router.post('/games/:id/reviews/add',
+// POST /games/:id/reviews
+router.post('/games/:id/reviews',
   authUser,
   csrfProtection,
   reviewValidators,
@@ -125,7 +125,7 @@ router.post('/games/:id/reviews/add',
 
       if (!currentUserReview.length) {
         await newReview.save()
-        res.redirect(`/games/${game.id}/reviews`)
+        return res.redirect(`/games/${game.id}/reviews`)
       } else {
         errors.push('Sorry, you\'ve already written a review for this game.');
       }

--- a/views/reviews.pug
+++ b/views/reviews.pug
@@ -46,7 +46,7 @@ block content
       if errors
         .review-errors
           +errorReport(errors)
-      form(action=`/games/${game.id}/reviews/add`, method="post")
+      form(action=`/games/${game.id}/reviews`, method="post")
         input(type='hidden', name='_csrf', value=csrfToken)
         .reviews__rating-label
           label(for="rating") Rate this game:


### PR DESCRIPTION
Fixed error with "Can't set headers after they are sent to the client". This happens because once you redirect, that should be the end of the route handler's actions. Inserted a `return ` statement to fix.